### PR TITLE
Add Hook to Jetpack Login SSO Intercept

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -475,6 +475,7 @@ class Jetpack_SSO {
 							);
 						?>
 					</h2>
+					<?php do_action( 'jetpack_sso_login_form' ); ?>
 				</div>
 
 			<?php endif; ?>


### PR DESCRIPTION
The current Jetpack SSO solution obfuscates other Single-Sign On solutions that have hooked into the standard login form and makes it unclear to users how to access those SSO buttons.

If a user has a plugin to login with another service, they may be confused/not understand where their other single-sign on button went and "Login with your Username and Password" isn't what they're trying to do -- they're trying to Login with Google, Twitter, etc.

There should be a hook to allow other products to hook-in to the Jetpack form so users can have multiple SSO solutions.